### PR TITLE
Fix for() loop variable declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ geocluster.prototype._cluster = function(elements, bias) {
 	var diff;
 
 	// calculate sum of differences
-	for (let i = 1; i < elements.length; i++) {
+	for (var i = 1; i < elements.length; i++) {
 		diff = self._dist(elements[i][0], elements[i][1], elements[i-1][0], elements[i-1][1]);
 		tot_diff += diff;
 		diffs.push(diff);

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ geocluster.prototype._cluster = function(elements, bias) {
 	var diff;
 
 	// calculate sum of differences
-	for (i = 1; i < elements.length; i++) {
+	for (let i = 1; i < elements.length; i++) {
 		diff = self._dist(elements[i][0], elements[i][1], elements[i-1][0], elements[i-1][1]);
 		tot_diff += diff;
 		diffs.push(diff);


### PR DESCRIPTION
Declare loop variable `i` with `let`. Not declaring it this way will cause the code to break, though I guess some compilers/transpilers will fix it (currently broken when running with vite/rollup, was not broken when running with craco/webpack).